### PR TITLE
.konflux/dockerfiles: update go builder image to 1.23

### DIFF
--- a/.konflux/dockerfiles/tkn.Dockerfile
+++ b/.konflux/dockerfiles/tkn.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22
+ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23
 ARG RUNTIME=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:dee813b83663d420eb108983a1c94c614ff5d3fcb5159a7bd0324f0edbe7fca1
 ARG PAC_BUILDER=registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8:v1.16.1-2
 


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
