### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-cli-1-18-tkn

### DIFF
--- a/.konflux/dockerfiles/tkn.Dockerfile
+++ b/.konflux/dockerfiles/tkn.Dockerfile
@@ -33,6 +33,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-cli-tkn-container" \
       name="openshift-pipelines/pipelines-cli-tkn-rhel9" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9" \
       summary="Red Hat OpenShift pipelines tkn CLI" \
       description="CLI client 'tkn' for managing openshift pipelines" \
       io.k8s.display-name="Red Hat OpenShift Pipelines tkn CLI" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
