### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-cli-1-14-tkn

### DIFF
--- a/.konflux/dockerfiles/tkn.Dockerfile
+++ b/.konflux/dockerfiles/tkn.Dockerfile
@@ -36,6 +36,7 @@ LABEL \
       io.k8s.display-name="Red Hat OpenShift Pipelines tkn CLI" \
       maintainer="pipelines-extcomm@redhat.com" \
       io.k8s.description="Red Hat OpenShift Pipelines tkn CLI" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.14::el8" \
       io.openshift.tags="pipelines,tekton,openshift"
 
 RUN groupadd -r -g 65532 nonroot && \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
