### PR TITLE
[1.21.x] chore: update pac submodule version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "sources/pac"]
 	path = sources/pac
 	url = https://github.com/tektoncd/pipelines-as-code.git
-	branch = release-v0.41.x
+	branch = release-v0.39.x


### PR DESCRIPTION
Pipelines 1.21.x corresponds to upstream pac 0.39.x.
Updated the submodule to point to the correct version.